### PR TITLE
Transaction Interface: check_resource_keys

### DIFF
--- a/benches/prio_graph.rs
+++ b/benches/prio_graph.rs
@@ -3,7 +3,7 @@
 extern crate test;
 
 use {
-    prio_graph::{PrioGraph, PriorityId, ResourceKey, Transaction},
+    prio_graph::{AccessKind, PrioGraph, PriorityId, ResourceKey, Transaction},
     rand::{distributions::Uniform, seq::SliceRandom, thread_rng, Rng},
     std::{collections::HashMap, fmt::Display},
     test::Bencher,
@@ -54,12 +54,13 @@ impl Transaction<TransactionPriorityId, AccountKey> for TestTransaction {
         self.id
     }
 
-    fn write_locked_resources(&self) -> &[AccountKey] {
-        &self.write_accounts
-    }
-
-    fn read_locked_resources(&self) -> &[AccountKey] {
-        &self.read_accounts
+    fn check_resource_keys<F: FnMut(&AccountKey, AccessKind)>(&self, mut checker: F) {
+        for account in &self.read_accounts {
+            checker(account, AccessKind::Read);
+        }
+        for account in &self.write_accounts {
+            checker(account, AccessKind::Write);
+        }
     }
 }
 

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -1,8 +1,11 @@
 use crate::{PriorityId, ResourceKey};
 
+pub enum AccessKind {
+    Read,
+    Write,
+}
+
 pub trait Transaction<Id: PriorityId, Rk: ResourceKey> {
     fn id(&self) -> Id;
-
-    fn write_locked_resources(&self) -> &[Rk];
-    fn read_locked_resources(&self) -> &[Rk];
+    fn check_resource_keys<F: FnMut(&Rk, AccessKind)>(&self, checker: F);
 }


### PR DESCRIPTION
- `solana_sdk::SanitizedTransaction` doesn't have contiguous chunks for read and write keys
- change to make it more customizable