### PR TITLE
Simplify interface and tracking

### DIFF
--- a/src/graph_node.rs
+++ b/src/graph_node.rs
@@ -6,10 +6,6 @@ pub struct GraphNode<Id: PriorityId> {
     /// Unique edges from this node.
     /// The number of edges is the same as the number of forks.
     pub edges: HashSet<Id>,
-    /// Cache the reward for this node.
-    pub reward: u64,
-    /// Reward at next level - i.e. how much is blocked by this.
-    pub next_level_rewards: u64,
     /// Number of edges into this node.
     pub blocked_by_count: usize,
     /// The distinct chain id of this node.

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -1,12 +1,10 @@
-use crate::{PriorityId, ResourceKey};
+use crate::ResourceKey;
 
 pub enum AccessKind {
     Read,
     Write,
 }
 
-pub trait Transaction<Id: PriorityId, Rk: ResourceKey> {
-    fn id(&self) -> Id;
-    fn reward(&self) -> u64;
+pub trait Transaction<Rk: ResourceKey> {
     fn check_resource_keys<F: FnMut(&Rk, AccessKind)>(&self, checker: F);
 }


### PR DESCRIPTION
- Not currently using next level rewards in top-level prioritization. Removing it.
- Remove Id and reward from the `Transaction` interface