### PR TITLE
Bugfix: Support self-conflicting access

### DIFF
--- a/src/prio_graph.rs
+++ b/src/prio_graph.rs
@@ -457,4 +457,19 @@ mod tests {
         );
         assert_eq!(batches, [vec![8, 7], vec![6, 5], vec![4, 3], vec![2, 1]]);
     }
+
+    #[test]
+    fn test_self_conflicting() {
+        // Setup:
+        //   - transaction read and write locks account 0.
+        // 1
+        // Batches: [1]
+        let (transaction_lookup_table, transaction_queue) =
+            setup_test([(vec![1], vec![0], vec![0])]);
+        let batches = PrioGraph::natural_batches(
+            create_lookup_iterator(&transaction_lookup_table, &transaction_queue),
+            test_top_level_priority_fn,
+        );
+        assert_eq!(batches, [vec![1]]);
+    }
 }

--- a/src/prio_graph.rs
+++ b/src/prio_graph.rs
@@ -478,4 +478,19 @@ mod tests {
         );
         assert_eq!(batches, [vec![1]]);
     }
+
+    #[test]
+    fn test_self_conflicting_write_priority() {
+        // Setup:
+        //   - transaction 2 read and write locks account 0.
+        // 2 --> 1
+        // Batches: [2, 1]
+        let (transaction_lookup_table, transaction_queue) =
+            setup_test([(vec![2], vec![0], vec![0]), (vec![1], vec![0], vec![])]);
+        let batches = PrioGraph::natural_batches(
+            create_lookup_iterator(&transaction_lookup_table, &transaction_queue),
+            test_top_level_priority_fn,
+        );
+        assert_eq!(batches, [vec![2], vec![1]]);
+    }
 }

--- a/src/prio_graph.rs
+++ b/src/prio_graph.rs
@@ -101,6 +101,12 @@ impl<
         let mut joined_chains = HashSet::new();
 
         let mut block_tx = |blocking_id: Id| {
+            // If the blocking transaction is the same as the current transaction, do nothing.
+            // This indicates the transaction has multiple accesses to the same resource.
+            if blocking_id == id {
+                return;
+            }
+
             let Some(blocking_tx_node) = self.nodes.get_mut(&blocking_id) else {
                 panic!("blocking node must exist");
             };


### PR DESCRIPTION
## Problem

The interface for transaction does not guarantee we have unique resource access.
It's possible to access the same resource multiple times, either with read-write or write-write conflict.
This currently would cause a panic, since when attempting to block by that resource we search for the node which has not yet been inserted.

## Solution

- Modify locks to not overwrite self-conflicting write
- In prio-graph insertion, ignore self on conflict
