### PR TITLE
Bugfix: Reads track most recent write

### DIFF
--- a/src/lock.rs
+++ b/src/lock.rs
@@ -4,7 +4,7 @@ use crate::TransactionId;
 /// subsequent write-locks should be blocked by all of them.
 /// Write-locks are exclusive.
 pub(crate) enum Lock<Id: TransactionId> {
-    Read(Vec<Id>),
+    Read(Vec<Id>, Option<Id>), // (Current Reads, Most Recent Write)
     Write(Id),
 }
 
@@ -13,17 +13,20 @@ impl<Id: TransactionId> Lock<Id> {
     /// Returns the id of the write transaction that is blocking the added read.
     pub fn add_read(&mut self, id: Id) -> Option<Id> {
         match self {
-            Lock::Read(ids) => {
+            Lock::Read(ids, maybe_write) => {
                 ids.push(id);
-                None
+                *maybe_write
             }
             Lock::Write(current_write_id) => {
                 // If the current write is the same as the one we're adding,
                 // do not overwrite the write-lock.
-                if *current_write_id == id {
+                let current_write_id = *current_write_id;
+                if current_write_id == id {
                     return None;
                 }
-                let Lock::Write(id) = core::mem::replace(self, Lock::Read(vec![id])) else {
+                let Lock::Write(id) =
+                    core::mem::replace(self, Lock::Read(vec![id], Some(current_write_id)))
+                else {
                     unreachable!("LockKind::Write is guaranteed by match");
                 };
                 Some(id)
@@ -35,7 +38,7 @@ impl<Id: TransactionId> Lock<Id> {
     /// Returns the ids of transactions blocking the added write.
     pub fn add_write(&mut self, id: Id) -> Option<Vec<Id>> {
         match core::mem::replace(self, Lock::Write(id)) {
-            Lock::Read(ids) => Some(ids),
+            Lock::Read(ids, _) => Some(ids),
             Lock::Write(current_write_id) => {
                 if current_write_id == id {
                     None

--- a/src/prio_graph.rs
+++ b/src/prio_graph.rs
@@ -493,4 +493,21 @@ mod tests {
         );
         assert_eq!(batches, [vec![2], vec![1]]);
     }
+
+    #[test]
+    fn test_write_read_read_conflict() {
+        // Setup:
+        //  - W --> R
+        //      \
+        //       -> R
+        // - all transactions using same account 0.
+        // Batches: [3], [2, 1]
+        let (transaction_lookup_table, transaction_queue) =
+            setup_test([(vec![3], vec![], vec![0]), (vec![2, 1], vec![0], vec![])]);
+        let batches = PrioGraph::natural_batches(
+            create_lookup_iterator(&transaction_lookup_table, &transaction_queue),
+            test_top_level_priority_fn,
+        );
+        assert_eq!(batches, [vec![3], vec![2, 1]]);
+    }
 }

--- a/src/prio_graph.rs
+++ b/src/prio_graph.rs
@@ -138,7 +138,7 @@ impl<
             match self.locks.entry(resource_key) {
                 Entry::Vacant(entry) => {
                     entry.insert(match access_kind {
-                        AccessKind::Read => Lock::Read(vec![id]),
+                        AccessKind::Read => Lock::Read(vec![id], None),
                         AccessKind::Write => Lock::Write(id),
                     });
                 }


### PR DESCRIPTION
Fixes #56 

- Read locks track the most recent write, if it exists, so that new reads will conflict with that write