### PR TITLE
Remove chain tracking

### DIFF
--- a/src/graph_node.rs
+++ b/src/graph_node.rs
@@ -12,6 +12,4 @@ pub struct GraphNode<Id: TransactionId> {
     /// Unique edges from this node.
     /// The number of edges is the same as the number of forks.
     pub edges: HashSet<Id>,
-    /// The distinct chain id of this node.
-    pub chain_id: u64,
 }


### PR DESCRIPTION
## Problem
Benchmarks show that chain-tracing logic slows down code by 15-20% in case of all conflicting transactions.
The logic of chain-tracing is not always required for the use-case. For example, the transaction scheduler in solana did but no longer uses the chains.
When chain tracking was introduced (#31) it wasn't possible to have the chain-tracking done externally.
But with #51, it should be possible to implement the chain tracking outside of the prio-graph itself as the calling code is popping and unblocking.
I'm removing this code to keep the crate simpler, and speed it up.

## Changes
Remove chain tracking code from prio-graph.
**This is a breaking change.**
