### PR TITLE
Use vec for storing edges

### DIFF
--- a/src/graph_node.rs
+++ b/src/graph_node.rs
@@ -1,4 +1,4 @@
-use {crate::TransactionId, ahash::AHashSet};
+use crate::TransactionId;
 
 /// A single node in a priority graph that is associated with a `Transaction`.
 /// When a node reaches the main queue, the top-level prioritization function can use a reference
@@ -11,5 +11,20 @@ pub struct GraphNode<Id: TransactionId> {
     pub(crate) blocked_by_count: usize,
     /// Unique edges from this node.
     /// The number of edges is the same as the number of forks.
-    pub edges: AHashSet<Id>,
+    pub edges: Vec<Id>,
+}
+
+impl<Id: TransactionId> GraphNode<Id> {
+    /// Returns true if the edge was added successfully.
+    /// Edges are only added if the edge is unique.
+    /// Because we always add edges as we insert, the edge is unique if the
+    /// `id` does not match the last element in the `edges` vector.
+    pub fn try_add_edge(&mut self, id: Id) -> bool {
+        if self.edges.last() == Some(&id) {
+            false
+        } else {
+            self.edges.push(id);
+            true
+        }
+    }
 }


### PR DESCRIPTION
## Problem 
#19 - Adjacency tracking performance is poor using a HashSet; resizing, hashing, etc.

## Changes

- Use a Vec to store edges instead of HashSet.
- Check only last item in vec, since we check only check edge uniqueness on insertion
- Fixes short-coming of #79. The public API now uses `Vec<Id>` as return type; no reliance on `ahash` types for exposed API.

Fixes #19 
