### PR TITLE
Sort ids in benchmarks

### DIFF
--- a/benches/prio_graph.rs
+++ b/benches/prio_graph.rs
@@ -81,12 +81,14 @@ impl TestTransaction {
 fn generate_priority_ids(num_transactions: u64) -> Vec<TransactionPriorityId> {
     let mut rng = thread_rng();
     let priority_distribution = Uniform::new(0, 1000);
-    (0..num_transactions)
+    let mut ids: Vec<_> = (0..num_transactions)
         .map(|id| TransactionPriorityId {
             id,
             priority: rng.sample(priority_distribution),
         })
-        .collect()
+        .collect();
+    ids.sort_unstable();
+    ids
 }
 
 fn bench_prio_graph(


### PR DESCRIPTION
## Problem
generated ids are not sorted in (non-tree) benchmark tests, which leads to unrealistic situations where the fed order is not reasonably close to the pop order.

## Changes
`generate_priority_ids` now sorts the ids by priority before returning.