### PR TITLE
Move and change natural_batches

### DIFF
--- a/benches/prio_graph.rs
+++ b/benches/prio_graph.rs
@@ -1,6 +1,6 @@
 use {
     criterion::{black_box, criterion_group, criterion_main, Criterion},
-    prio_graph::{AccessKind, PrioGraph, TopLevelId},
+    prio_graph::{AccessKind, TopLevelId},
     rand::{distributions::Uniform, seq::SliceRandom, thread_rng, Rng},
     std::{fmt::Display, hash::Hash},
 };
@@ -99,7 +99,7 @@ fn bench_prio_graph(
     // Begin bench.
     bencher.bench_function(name, |bencher| {
         bencher.iter(|| {
-            let _batches = black_box(PrioGraph::natural_batches(
+            let _batches = black_box(prio_graph::natural_batches(
                 ids_and_txs.iter().map(|(id, tx)| (*id, tx.resources())),
                 |id, _| *id,
             ));


### PR DESCRIPTION
## Problem
- Ideally would be able to benchmark insertion separately from popping
- However, cannot easily do that with the current impl of `PrioGraph::natural_batches`

## Changes
**Breaking Change**
- Move existing `PrioGraph::natural_batches` to module level i.e. `prio_graph::natural_batches`
- Change `PrioGraph::natural_batches` to operate on an already initialized graph to create batches in same manner as previously done
- Make `prio_graph::natural_batches` insert then call `graph.natural_batches()`