### PR TITLE
Benchmark: Feature-activated switch for benching only insertion or popping

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,7 @@ rand = { version = "0.8.4" }
 [[bench]]
 name = "prio_graph"
 harness = false
+
+[features]
+bench-insertion-only = []
+bench-popping-only = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,5 +21,7 @@ name = "prio_graph"
 harness = false
 
 [features]
+# Benchmark graph insertion only. Conflicts with `bench-popping-only`
 bench-insertion-only = []
+# Benchmark graph popping only. Conflicts with `bench-insertion-only`
 bench-popping-only = []

--- a/benches/prio_graph.rs
+++ b/benches/prio_graph.rs
@@ -1,6 +1,6 @@
 use {
     criterion::{black_box, criterion_group, criterion_main, Criterion},
-    prio_graph::{AccessKind, PrioGraph, TopLevelId},
+    prio_graph::{AccessKind, TopLevelId},
     rand::{distributions::Uniform, seq::SliceRandom, thread_rng, Rng},
     std::{fmt::Display, hash::Hash},
 };
@@ -99,7 +99,7 @@ fn bench_prio_graph(
     // Begin bench.
     bencher.bench_function(name, |bencher| {
         bencher.iter(|| {
-            let _batches = black_box(PrioGraph::natural_batches(
+            let _batches = black_box(prio_graph::natural_batches(
                 ids_and_txs.iter().map(|(id, tx)| (*id, tx.resources())),
                 |id, _| *id,
             ));


### PR DESCRIPTION
## Problem
Want a way to optionally and easily benchmark either insertion or popping separate from the other using the same benchmarks.

## Changes
Introduce 2 compile-time features:
- `bench-insertion-only`
- `bench-popping-only`
which will bench graph insertion and popping instead of insertion + popping, using the same benchmarks as without the features.
These 2 features conflict with each other and will result in a compiler error during bench.
The features have no affect on non-bench code.

Blocked by #75 