### PR TITLE
Keyed graph

### DIFF
--- a/src/graph_node.rs
+++ b/src/graph_node.rs
@@ -5,11 +5,14 @@ use {crate::TransactionId, std::collections::HashSet};
 /// to this node to calculate a modified priority for the node, which is only used for
 /// prioritization for the main queue.
 pub struct GraphNode<Id: TransactionId> {
+    /// The `Id` of the node.
+    pub(crate) id: Id,
     /// Whether this node is active, i.e. has not been removed from the main queue.
     pub(crate) active: bool,
     /// Number of edges into this node.
     pub(crate) blocked_by_count: usize,
     /// Unique edges from this node.
+    /// Values are indices into the `prio_graph`'s `nodes` vector.
     /// The number of edges is the same as the number of forks.
-    pub edges: HashSet<Id>,
+    pub edges: HashSet<usize>,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ mod prio_graph;
 mod resource_key;
 mod top_level_id;
 mod transaction_id;
+mod transaction_key;
 
 pub use crate::{
     graph_node::*, prio_graph::*, resource_key::*, top_level_id::*, transaction_id::*,

--- a/src/lock.rs
+++ b/src/lock.rs
@@ -1,49 +1,47 @@
-use crate::TransactionId;
-
 /// A read-lock can be held by multiple transactions, and
 /// subsequent write-locks should be blocked by all of them.
 /// Write-locks are exclusive.
-pub(crate) enum Lock<Id: TransactionId> {
-    Read(Vec<Id>, Option<Id>), // (Current Reads, Most Recent Write)
-    Write(Id),
+pub(crate) enum Lock {
+    Read(Vec<usize>, Option<usize>), // (Current Reads, Most Recent Write)
+    Write(usize),
 }
 
-impl<Id: TransactionId> Lock<Id> {
+impl Lock {
     /// Take read-lock on a resource.
     /// Returns the id of the write transaction that is blocking the added read.
-    pub fn add_read(&mut self, id: Id) -> Option<Id> {
+    pub fn add_read(&mut self, index: usize) -> Option<usize> {
         match self {
-            Lock::Read(ids, maybe_write) => {
-                ids.push(id);
+            Lock::Read(indices, maybe_write) => {
+                indices.push(index);
                 *maybe_write
             }
-            Lock::Write(current_write_id) => {
+            Lock::Write(current_write_index) => {
                 // If the current write is the same as the one we're adding,
                 // do not overwrite the write-lock.
-                let current_write_id = *current_write_id;
-                if current_write_id == id {
+                let current_write_index = *current_write_index;
+                if current_write_index == index {
                     return None;
                 }
-                let Lock::Write(id) =
-                    core::mem::replace(self, Lock::Read(vec![id], Some(current_write_id)))
+                let Lock::Write(index) =
+                    core::mem::replace(self, Lock::Read(vec![index], Some(current_write_index)))
                 else {
                     unreachable!("LockKind::Write is guaranteed by match");
                 };
-                Some(id)
+                Some(index)
             }
         }
     }
 
     /// Take write-lock on a resource.
     /// Returns the ids of transactions blocking the added write.
-    pub fn add_write(&mut self, id: Id) -> Option<Vec<Id>> {
-        match core::mem::replace(self, Lock::Write(id)) {
-            Lock::Read(ids, _) => Some(ids),
-            Lock::Write(current_write_id) => {
-                if current_write_id == id {
+    pub fn add_write(&mut self, index: usize) -> Option<Vec<usize>> {
+        match core::mem::replace(self, Lock::Write(index)) {
+            Lock::Read(indices, _) => Some(indices),
+            Lock::Write(current_write_index) => {
+                if current_write_index == index {
                     None
                 } else {
-                    Some(vec![current_write_id])
+                    Some(vec![current_write_index])
                 }
             }
         }

--- a/src/top_level_id.rs
+++ b/src/top_level_id.rs
@@ -1,6 +1,49 @@
-use crate::TransactionId;
+use crate::{transaction_key::TransactionKey, TransactionId};
 
 /// A top-level ID that should contain the unique `Id`, but can be priority ordered.
 pub trait TopLevelId<Id: TransactionId>: Eq + PartialEq + Ord + PartialOrd {
     fn id(&self) -> Id;
+}
+
+pub(crate) struct TopLevelIdWrapper<Id: TransactionId, Tl: TopLevelId<Id>> {
+    pub top_level_id: Tl,
+    pub index: usize,
+
+    _id: core::marker::PhantomData<Id>,
+}
+
+impl<Id: TransactionId, Tl: TopLevelId<Id>> TopLevelIdWrapper<Id, Tl> {
+    pub(crate) fn new(top_level_id: Tl, index: usize) -> Self {
+        Self {
+            top_level_id,
+            index,
+            _id: core::marker::PhantomData,
+        }
+    }
+}
+
+impl<Id: TransactionId, Tl: TopLevelId<Id>> Eq for TopLevelIdWrapper<Id, Tl> {}
+
+impl<Id: TransactionId, Tl: TopLevelId<Id>> PartialEq for TopLevelIdWrapper<Id, Tl> {
+    fn eq(&self, other: &Self) -> bool {
+        self.top_level_id == other.top_level_id
+    }
+}
+
+impl<Id: TransactionId, Tl: TopLevelId<Id>> Ord for TopLevelIdWrapper<Id, Tl> {
+    fn cmp(&self, other: &Self) -> core::cmp::Ordering {
+        self.top_level_id.cmp(&other.top_level_id)
+    }
+}
+
+impl<Id: TransactionId, Tl: TopLevelId<Id>> PartialOrd for TopLevelIdWrapper<Id, Tl> {
+    fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl<Id: TransactionId, Tl: TopLevelId<Id>> From<TopLevelIdWrapper<Id, Tl>> for TransactionKey<Id> {
+    fn from(wrapper: TopLevelIdWrapper<Id, Tl>) -> Self {
+        TransactionKey::new(wrapper.top_level_id.id(), wrapper.index)
+    }
 }

--- a/src/transaction_key.rs
+++ b/src/transaction_key.rs
@@ -1,0 +1,34 @@
+use crate::TransactionId;
+
+/// TransactionKey is a struct that can be used to uniquely identify a transaction.
+/// It wraps a `TransactionId`, and the `id` can be extracted from it.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub struct TransactionKey<Id: TransactionId> {
+    /// Wrapped `TransactionId`
+    id: Id,
+    /// Index into internal structures for the transaction's
+    /// node in the graph. This is not needed by code outside
+    /// of this crate, and is only used internally.
+    index: usize,
+}
+
+impl<Id: TransactionId> TransactionKey<Id> {
+    /// Creates a new `TransactionKey` from a `TransactionId` and an index.
+    /// This function is only used internally, and should not be used by
+    /// code outside of this crate.
+    pub(crate) fn new(id: Id, index: usize) -> Self {
+        Self { id, index }
+    }
+
+    /// Returns the `TransactionId` wrapped by this `TransactionKey`.
+    pub fn id(&self) -> &Id {
+        &self.id
+    }
+
+    /// Returns the index of the transaction's node in the graph.
+    /// This is not needed by code outside of this crate, and is only
+    /// used internally.
+    pub(crate) fn index(&self) -> usize {
+        self.index
+    }
+}


### PR DESCRIPTION
## Problem
- Every node lookup is hashing the `TransactionId` which can be expensive since it is done very often

## Changes
**Breaking Change**
- Exposed Changes:
	- Introduce `TransactionKey` which wraps `TransactionId` with an index
	- `pop_and_unblock` now returns `Option<(TransactionKey<Id>, HashSet<usize>)>`
	- `pop` now returns an `Option<(TransactionKey<Id>)>`
	- `unblock` now takes a `TransactionKey<Id>` and returns `HashSet<usize>`
	- `is_blocked` takes a `&TransactionKey<Id>`
- Internal Changes:
	- Graph Nodes:
	  	- Stored in indexable Vec, using index from `TransactionKey` as lookup key. Currently this is append only, so there's no index invalidation.
	  	- Store the `TransactionId` on the node (needed to recreate `TransactionKey` on retrieval)
	  	- `edges` now stores indexes to other nodes instead of `TransactionId`s (this is publicly exposed through the top-level prioritization function)
	- Locks - use index instead of `TransactionId` for storing most-recent accesses
