### PR TITLE
Use ahash sets and maps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ edition = "2021"
 include = ["src/*.rs", "Cargo.toml"]
 
 [dependencies]
+ahash = { version = "0.8.11" }
 
 [dev-dependencies]
 criterion = { version = "0.5.1" }

--- a/src/graph_node.rs
+++ b/src/graph_node.rs
@@ -1,4 +1,4 @@
-use {crate::TransactionId, std::collections::HashSet};
+use {crate::TransactionId, ahash::AHashSet};
 
 /// A single node in a priority graph that is associated with a `Transaction`.
 /// When a node reaches the main queue, the top-level prioritization function can use a reference
@@ -11,5 +11,5 @@ pub struct GraphNode<Id: TransactionId> {
     pub(crate) blocked_by_count: usize,
     /// Unique edges from this node.
     /// The number of edges is the same as the number of forks.
-    pub edges: HashSet<Id>,
+    pub edges: AHashSet<Id>,
 }


### PR DESCRIPTION
### Problem

- Hashing is one of the most time-consuming parts of prio-graph
- We do hashing on our resource keys (for benches [u8; 32])

### Solution

- Use ahash library for all maps and sets

### Drawbacks

- The return type on `unblock` was changed, we should not expose the details of our hashmap here
- There is a follow-up change I am doing to change this to a more stable type: `Vec<Id>`
- Will not release this code in a version without the follow-up