### PR TITLE
Refactor: Lock Storage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ include = ["src/*.rs", "Cargo.toml"]
 
 [dependencies]
 ahash = { version = "0.8.11" }
+smallvec = { version = "1.13.2" }
 
 [dev-dependencies]
 criterion = { version = "0.5.1" }

--- a/src/lock.rs
+++ b/src/lock.rs
@@ -10,6 +10,11 @@ pub(crate) struct Lock<Id: TransactionId> {
     kind: AccessKind,
     // Current Reads or Write
     current_locks: SmallVec<[Id; 4]>,
+    // This can only be populated when the current lock is a read-lock, and
+    // there has been a previous write-lock.
+    // Tracks the most recent, but not current, write-lock.
+    // It is necessary to track, because all current read-locks will conflict
+    // with the most recent write-lock.
     most_recent_write: Option<Id>,
 }
 

--- a/src/lock.rs
+++ b/src/lock.rs
@@ -9,7 +9,7 @@ use {
 pub(crate) struct Lock<Id: TransactionId> {
     kind: AccessKind,
     // Current Reads or Write
-    current_locks: SmallVec<[Id; 4]>,
+    current_locks: SmallVec<[Id; 1]>,
     // This can only be populated when the current lock is a read-lock, and
     // there has been a previous write-lock.
     // Tracks the most recent, but not current, write-lock.

--- a/src/lock.rs
+++ b/src/lock.rs
@@ -1,50 +1,74 @@
-use crate::TransactionId;
+use crate::{AccessKind, TransactionId};
 
 /// A read-lock can be held by multiple transactions, and
 /// subsequent write-locks should be blocked by all of them.
 /// Write-locks are exclusive.
-pub(crate) enum Lock<Id: TransactionId> {
-    Read(Vec<Id>, Option<Id>), // (Current Reads, Most Recent Write)
-    Write(Id),
+pub(crate) struct Lock<Id: TransactionId> {
+    kind: AccessKind,
+    // Current Reads or Write
+    current_locks: Vec<Id>,
+    most_recent_write: Option<Id>,
 }
 
 impl<Id: TransactionId> Lock<Id> {
-    /// Take read-lock on a resource.
-    /// Returns the id of the write transaction that is blocking the added read.
-    pub fn add_read(&mut self, id: Id) -> Option<Id> {
-        match self {
-            Lock::Read(ids, maybe_write) => {
-                ids.push(id);
-                *maybe_write
+    pub fn new(id: Id, kind: AccessKind) -> Self {
+        Self {
+            kind,
+            current_locks: vec![id],
+            most_recent_write: None,
+        }
+    }
+
+    pub fn add_read(&mut self, id: Id, conflict_callback: &mut impl FnMut(&Id)) {
+        match self.kind {
+            AccessKind::Read => {
+                self.current_locks.push(id);
+                if let Some(write) = self.most_recent_write.as_ref() {
+                    conflict_callback(write);
+                }
             }
-            Lock::Write(current_write_id) => {
+            AccessKind::Write => {
+                debug_assert_eq!(self.current_locks.len(), 1);
                 // If the current write is the same as the one we're adding,
                 // do not overwrite the write-lock.
-                let current_write_id = *current_write_id;
+                let current_write_id = self.current_locks[0];
                 if current_write_id == id {
-                    return None;
+                    return;
                 }
-                let Lock::Write(id) =
-                    core::mem::replace(self, Lock::Read(vec![id], Some(current_write_id)))
-                else {
-                    unreachable!("LockKind::Write is guaranteed by match");
-                };
-                Some(id)
+
+                for id in self.current_locks.drain(..) {
+                    conflict_callback(&id);
+                }
+                self.kind = AccessKind::Read;
+                self.current_locks.push(id);
+                self.most_recent_write = Some(current_write_id);
             }
         }
     }
 
     /// Take write-lock on a resource.
-    /// Returns the ids of transactions blocking the added write.
-    pub fn add_write(&mut self, id: Id) -> Option<Vec<Id>> {
-        match core::mem::replace(self, Lock::Write(id)) {
-            Lock::Read(ids, _) => Some(ids),
-            Lock::Write(current_write_id) => {
-                if current_write_id == id {
-                    None
-                } else {
-                    Some(vec![current_write_id])
+    /// For each conflicting lock, call the `conflict_callback`.
+    pub fn add_write(&mut self, id: Id, conflict_callback: &mut impl FnMut(&Id)) {
+        self.most_recent_write = None;
+        match self.kind {
+            AccessKind::Read => {
+                for id in self.current_locks.drain(..) {
+                    conflict_callback(&id);
                 }
+                self.kind = AccessKind::Write;
+                self.current_locks.push(id);
+            }
+            AccessKind::Write => {
+                debug_assert_eq!(self.current_locks.len(), 1);
+                let current_write_id = self.current_locks[0];
+                if current_write_id == id {
+                    return;
+                }
+
+                for id in self.current_locks.drain(..) {
+                    conflict_callback(&id);
+                }
+                self.current_locks.push(id);
             }
         }
     }

--- a/src/lock.rs
+++ b/src/lock.rs
@@ -1,4 +1,7 @@
-use crate::{AccessKind, TransactionId};
+use {
+    crate::{AccessKind, TransactionId},
+    smallvec::{smallvec, SmallVec},
+};
 
 /// A read-lock can be held by multiple transactions, and
 /// subsequent write-locks should be blocked by all of them.
@@ -6,7 +9,7 @@ use crate::{AccessKind, TransactionId};
 pub(crate) struct Lock<Id: TransactionId> {
     kind: AccessKind,
     // Current Reads or Write
-    current_locks: Vec<Id>,
+    current_locks: SmallVec<[Id; 4]>,
     most_recent_write: Option<Id>,
 }
 
@@ -14,7 +17,7 @@ impl<Id: TransactionId> Lock<Id> {
     pub fn new(id: Id, kind: AccessKind) -> Self {
         Self {
             kind,
-            current_locks: vec![id],
+            current_locks: smallvec![id],
             most_recent_write: None,
         }
     }

--- a/src/lock.rs
+++ b/src/lock.rs
@@ -44,9 +44,10 @@ impl<Id: TransactionId> Lock<Id> {
                     return;
                 }
 
-                for id in self.current_locks.drain(..) {
-                    conflict_callback(&id);
-                }
+                // Only single lock, so call on the conflict and
+                // clear the current lock.
+                conflict_callback(&current_write_id);
+                self.current_locks.clear();
                 self.kind = AccessKind::Read;
                 self.current_locks.push(id);
                 self.most_recent_write = Some(current_write_id);
@@ -73,9 +74,11 @@ impl<Id: TransactionId> Lock<Id> {
                     return;
                 }
 
-                for id in self.current_locks.drain(..) {
-                    conflict_callback(&id);
-                }
+                // Only single lock, so call on the conflict and
+                // clear the current lock.
+                conflict_callback(&current_write_id);
+                self.current_locks.clear();
+
                 self.current_locks.push(id);
             }
         }


### PR DESCRIPTION
## Problem

- We store locks for every touched account
- When there are many conflicts on the account(s) we are sometimes dropping and allocating a vec on each access


## Solution

- Re-use the lock storage so we never free the vec we are using
- Use a smallvec so there is no initial heap allocation per lock