### PR TITLE
PrioGraph::clear

### DIFF
--- a/benches/prio_graph.rs
+++ b/benches/prio_graph.rs
@@ -97,12 +97,14 @@ fn bench_prio_graph(
     ids_and_txs: &[(TransactionPriorityId, TestTransaction)],
 ) {
     // Begin bench.
+    let mut prio_graph = PrioGraph::new(|id, _| *id);
     bencher.bench_function(name, |bencher| {
         bencher.iter(|| {
-            let _batches = black_box(PrioGraph::natural_batches(
-                ids_and_txs.iter().map(|(id, tx)| (*id, tx.resources())),
-                |id, _| *id,
-            ));
+            for (id, tx) in ids_and_txs.iter() {
+                prio_graph.insert_transaction(*id, tx.resources());
+            }
+            let _batches = black_box(prio_graph.make_natural_batches());
+            prio_graph.clear();
         });
     });
 }

--- a/src/prio_graph.rs
+++ b/src/prio_graph.rs
@@ -63,6 +63,13 @@ impl<
         }
     }
 
+    /// Clear the graph.
+    pub fn clear(&mut self) {
+        self.main_queue.clear();
+        self.locks.clear();
+        self.nodes.clear();
+    }
+
     /// Make natural batches from the transactions already inserted into the graph.
     /// Drains all transactions from the primary queue into a batch.
     /// Then, for each transaction in the batch, unblock transactions it was blocking.


### PR DESCRIPTION
## Problem

- We have top-level allocations for our nodes, locks, and main queue
- Everytime we create a new prio_graph, these allocations start off with a capacity of 0
- Re-sizing these top-level containers can be expensive

## Solution

- Allow the prio_graph to be re-usable by adding a `clear` method
- Update benchmark to use `insert, make_natural_batches, clear` approach