### PR TITLE
specify path for bench

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,4 +19,5 @@ rand = { version = "0.8.4" }
 
 [[bench]]
 name = "prio_graph"
+path = "benches/prio_graph.rs"
 harness = false


### PR DESCRIPTION
- Without this, cargo is too dumb to realize that the file exists:

```
    Updating crates.io index
   Packaging prio-graph v0.3.0 (/Users/apfitzge/Documents/dev/prio-graph/worktrees/main)
   Verifying prio-graph v0.3.0 (/Users/apfitzge/Documents/dev/prio-graph/worktrees/main)
error: failed to verify package tarball

Caused by:
  failed to parse manifest at `/Users/apfitzge/Documents/dev/prio-graph/worktrees/main/target/package/prio-graph-0.3.0/Cargo.toml`

Caused by:
  can't find `prio_graph` bench at `benches/prio_graph.rs` or `benches/prio_graph/main.rs`. Please specify bench.path if you want to use a non-default path.
```

Rather than fighting this, just specify the path to fix it. Even though it's literally at the path they stated.