### PR TITLE
add blanket impl for toplevel id trait

### DIFF
--- a/benches/prio_graph.rs
+++ b/benches/prio_graph.rs
@@ -3,7 +3,7 @@ use {
         black_box, criterion_group, criterion_main, measurement::Measurement, BenchmarkGroup,
         Criterion,
     },
-    prio_graph::{AccessKind, PrioGraph, TopLevelId},
+    prio_graph::{AccessKind, PrioGraph},
     rand::{distributions::Uniform, seq::SliceRandom, thread_rng, Rng},
     std::{fmt::Display, hash::Hash},
 };
@@ -38,12 +38,6 @@ impl PartialOrd for TransactionPriorityId {
 impl Display for TransactionPriorityId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "(id: {}, prio: {})", self.id, self.priority)
-    }
-}
-
-impl TopLevelId<TransactionPriorityId> for TransactionPriorityId {
-    fn id(&self) -> TransactionPriorityId {
-        *self
     }
 }
 

--- a/src/prio_graph.rs
+++ b/src/prio_graph.rs
@@ -295,12 +295,6 @@ mod tests {
         })
     }
 
-    impl TopLevelId<TxId> for TxId {
-        fn id(&self) -> TxId {
-            *self
-        }
-    }
-
     fn test_top_level_priority_fn(id: &TxId, _node: &GraphNode<TxId>) -> TxId {
         *id
     }

--- a/src/top_level_id.rs
+++ b/src/top_level_id.rs
@@ -4,3 +4,18 @@ use crate::TransactionId;
 pub trait TopLevelId<Id: TransactionId>: Eq + PartialEq + Ord + PartialOrd {
     fn id(&self) -> Id;
 }
+
+
+impl<Id: TransactionId + Ord> TopLevelId<Id> for Id {
+    fn id(&self) -> Id {
+        self.clone()
+    }
+}
+
+
+#[test]
+fn integration_test_u64() {
+    let id: u64 = 123;
+    let toplevel_id = <u64 as TopLevelId<u64>>::id(&id);
+    assert_eq!(id, toplevel_id);
+}

--- a/src/top_level_id.rs
+++ b/src/top_level_id.rs
@@ -5,13 +5,11 @@ pub trait TopLevelId<Id: TransactionId>: Eq + PartialEq + Ord + PartialOrd {
     fn id(&self) -> Id;
 }
 
-
 impl<Id: TransactionId + Ord> TopLevelId<Id> for Id {
     fn id(&self) -> Id {
-        self.clone()
+        *self
     }
 }
-
 
 #[test]
 fn integration_test_u64() {


### PR DESCRIPTION
In the test suite, u64 is used as a toplevel id. This is possible because the trait impl is still defined in the same crate. If I wanted to use u64 as a toplevel id in an external crate, that would be an attempt to implement an external trait on an external (primitive) type. So, we do a blanket impl to cover these cases. 